### PR TITLE
Add spending summary feature

### DIFF
--- a/src/bank/Account.java
+++ b/src/bank/Account.java
@@ -163,6 +163,35 @@ public class Account {
                 + " remaining this month).";
     }
 
+    public SpendingSummary getSpendingSummary(long fromMs, long toMs) {
+        double totalDeposited = 0;
+        double totalWithdrawn = 0;
+        int depositCount = 0;
+        int withdrawalCount = 0;
+
+        for (Transaction t : transactionHistory) {
+            if (t.getWhenMs() < fromMs || t.getWhenMs() > toMs) {
+                continue;
+            }
+            switch (t.getType()) {
+                case DEPOSIT:
+                case TRANSFER_IN:
+                    totalDeposited += t.getAmount();
+                    depositCount++;
+                    break;
+                case WITHDRAW:
+                case TRANSFER_OUT:
+                    totalWithdrawn += t.getAmount();
+                    withdrawalCount++;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return new SpendingSummary(totalDeposited, totalWithdrawn, depositCount, withdrawalCount, fromMs, toMs);
+    }
+
     public List<Transaction> getTransactionHistoryByType(Transaction.Type type) {
         List<Transaction> out = new ArrayList<>();
 

--- a/src/bank/Bank.java
+++ b/src/bank/Bank.java
@@ -158,6 +158,52 @@ public class Bank {
         return CloseAccountResult.success();
     }
 
+    public SpendingSummaryResult getSpendingSummary(String accountId, long fromMs, long toMs) {
+        if (accountId == null || accountId.isBlank()) {
+            return SpendingSummaryResult.failure("Account id cannot be empty.");
+        }
+        if (fromMs > toMs) {
+            return SpendingSummaryResult.failure("Start date must not be after end date.");
+        }
+        Account acc = accounts.get(accountId);
+        if (acc == null) {
+            return SpendingSummaryResult.failure("Account not found: " + accountId);
+        }
+        return SpendingSummaryResult.success(acc.getSpendingSummary(fromMs, toMs));
+    }
+
+    public static final class SpendingSummaryResult {
+        private final boolean success;
+        private final String message;
+        private final SpendingSummary summary;
+
+        private SpendingSummaryResult(boolean success, String message, SpendingSummary summary) {
+            this.success = success;
+            this.message = message;
+            this.summary = summary;
+        }
+
+        public static SpendingSummaryResult success(SpendingSummary summary) {
+            return new SpendingSummaryResult(true, null, summary);
+        }
+
+        public static SpendingSummaryResult failure(String message) {
+            return new SpendingSummaryResult(false, message, null);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public SpendingSummary getSummary() {
+            return summary;
+        }
+    }
+
     public static final class CreateAccountResult {
         private final boolean success;
         private final String message;

--- a/src/bank/SpendingSummary.java
+++ b/src/bank/SpendingSummary.java
@@ -1,0 +1,50 @@
+package bank;
+
+public final class SpendingSummary {
+
+    private final double totalDeposited;
+    private final double totalWithdrawn;
+    private final int depositCount;
+    private final int withdrawalCount;
+    private final long fromMs;
+    private final long toMs;
+
+    SpendingSummary(double totalDeposited, double totalWithdrawn,
+                    int depositCount, int withdrawalCount,
+                    long fromMs, long toMs) {
+        this.totalDeposited = totalDeposited;
+        this.totalWithdrawn = totalWithdrawn;
+        this.depositCount = depositCount;
+        this.withdrawalCount = withdrawalCount;
+        this.fromMs = fromMs;
+        this.toMs = toMs;
+    }
+
+    public double getTotalDeposited() {
+        return totalDeposited;
+    }
+
+    public double getTotalWithdrawn() {
+        return totalWithdrawn;
+    }
+
+    public int getDepositCount() {
+        return depositCount;
+    }
+
+    public int getWithdrawalCount() {
+        return withdrawalCount;
+    }
+
+    public double getNetChange() {
+        return totalDeposited - totalWithdrawn;
+    }
+
+    public long getFromMs() {
+        return fromMs;
+    }
+
+    public long getToMs() {
+        return toMs;
+    }
+}

--- a/src/main/MainMenu.java
+++ b/src/main/MainMenu.java
@@ -5,18 +5,22 @@ import bank.AccountType;
 import bank.Bank;
 import bank.BankPersistence;
 import bank.PinLogin;
+import bank.SpendingSummary;
 import bank.Transaction;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 
 public class MainMenu {
 
-    private static final int EXIT_SELECTION = 12;
-    private static final int MAX_SELECTION = 12;
+    private static final int EXIT_SELECTION = 13;
+    private static final int MAX_SELECTION = 13;
 
     private final Bank bank;
     private String activeAccountId;
@@ -70,7 +74,8 @@ public class MainMenu {
         System.out.println("9. View balances for all accounts");
         System.out.println("10. Operator — freeze account");
         System.out.println("11. Operator — unfreeze account");
-        System.out.println("12. Exit the app");
+        System.out.println("12. View spending summary");
+        System.out.println("13. Exit the app");
     }
 
     public int getUserSelection(int max) {
@@ -131,6 +136,10 @@ public class MainMenu {
                 break;
 
             case 12:
+                viewSpendingSummary();
+                break;
+
+            case 13:
                 persistBankState();
                 System.out.println("Goodbye!");
                 break;
@@ -484,6 +493,40 @@ public class MainMenu {
         String line = keyboardInput.nextLine().trim();
 
         return line.equalsIgnoreCase("y") || line.equalsIgnoreCase("yes");
+    }
+
+    private void viewSpendingSummary() {
+        System.out.println("Spending summary for account: " + activeAccountId);
+        LocalDate from = readDate("Start date (YYYY-MM-DD): ");
+        LocalDate to = readDate("End date   (YYYY-MM-DD): ");
+
+        ZoneId zone = ZoneId.systemDefault();
+        long fromMs = from.atStartOfDay(zone).toInstant().toEpochMilli();
+        long toMs = to.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli() - 1;
+
+        Bank.SpendingSummaryResult result = bank.getSpendingSummary(activeAccountId, fromMs, toMs);
+        if (!result.isSuccess()) {
+            System.out.println(result.getMessage());
+            return;
+        }
+
+        SpendingSummary s = result.getSummary();
+        System.out.printf("Period:      %s to %s%n", from, to);
+        System.out.printf("Inflows:    +$%.2f (%d transaction(s))%n", s.getTotalDeposited(), s.getDepositCount());
+        System.out.printf("Outflows:   -$%.2f (%d transaction(s))%n", s.getTotalWithdrawn(), s.getWithdrawalCount());
+        System.out.printf("Net change:  $%.2f%n", s.getNetChange());
+    }
+
+    private LocalDate readDate(String prompt) {
+        while (true) {
+            System.out.print(prompt);
+            String line = keyboardInput.nextLine().trim();
+            try {
+                return LocalDate.parse(line);
+            } catch (DateTimeParseException ignored) {
+            }
+            System.out.println("Enter a date in YYYY-MM-DD format (e.g. 2025-01-31).");
+        }
     }
 
     private double readPositiveMoney(String prompt) {

--- a/src/test/SpendingSummaryTest.java
+++ b/src/test/SpendingSummaryTest.java
@@ -1,0 +1,246 @@
+package test;
+
+import bank.Account;
+import bank.AccountType;
+import bank.Bank;
+import bank.SpendingSummary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpendingSummaryTest {
+
+    // Use a fixed "now" so tests are deterministic
+    private static final long T0 = 1_700_000_000_000L; // arbitrary fixed epoch ms
+    private static final long ONE_DAY = 24 * 60 * 60 * 1000L;
+
+    // --- Bank-level validation ---
+
+    @Test
+    void unknownAccountReturnsFailure() {
+        Bank bank = new Bank();
+        Bank.SpendingSummaryResult r = bank.getSpendingSummary("NOPE", T0, T0 + ONE_DAY);
+        assertFalse(r.isSuccess());
+    }
+
+    @Test
+    void blankAccountIdReturnsFailure() {
+        Bank bank = new Bank();
+        assertFalse(bank.getSpendingSummary("", T0, T0 + ONE_DAY).isSuccess());
+    }
+
+    @Test
+    void startAfterEndReturnsFailure() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        assertFalse(bank.getSpendingSummary("A", T0 + ONE_DAY, T0).isSuccess());
+    }
+
+    @Test
+    void validRequestReturnsSuccess() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        assertTrue(bank.getSpendingSummary("A", T0, T0 + ONE_DAY).isSuccess());
+        assertNotNull(bank.getSpendingSummary("A", T0, T0 + ONE_DAY).getSummary());
+    }
+
+    // --- Deposit counting ---
+
+    @Test
+    void depositsInRangeAreCountedAsInflows() {
+        Account acc = new Account("A", 0);
+        long mid = T0 + ONE_DAY;
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 50.0, mid);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(50.0, s.getTotalDeposited(), 0.001);
+        assertEquals(0.0, s.getTotalWithdrawn(), 0.001);
+        assertEquals(1, s.getDepositCount());
+        assertEquals(0, s.getWithdrawalCount());
+        assertEquals(50.0, s.getNetChange(), 0.001);
+    }
+
+    @Test
+    void transferInCountsAsInflow() {
+        Account acc = new Account("A", 0);
+        long mid = T0 + ONE_DAY;
+        injectTransaction(acc, bank.Transaction.Type.TRANSFER_IN, 30.0, mid);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(30.0, s.getTotalDeposited(), 0.001);
+        assertEquals(1, s.getDepositCount());
+    }
+
+    // --- Withdrawal counting ---
+
+    @Test
+    void withdrawalsInRangeAreCountedAsOutflows() {
+        Account acc = new Account("A", 200);
+        long mid = T0 + ONE_DAY;
+        injectTransaction(acc, bank.Transaction.Type.WITHDRAW, 40.0, mid);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(0.0, s.getTotalDeposited(), 0.001);
+        assertEquals(40.0, s.getTotalWithdrawn(), 0.001);
+        assertEquals(0, s.getDepositCount());
+        assertEquals(1, s.getWithdrawalCount());
+        assertEquals(-40.0, s.getNetChange(), 0.001);
+    }
+
+    @Test
+    void transferOutCountsAsOutflow() {
+        Account acc = new Account("A", 200);
+        long mid = T0 + ONE_DAY;
+        injectTransaction(acc, bank.Transaction.Type.TRANSFER_OUT, 25.0, mid);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(25.0, s.getTotalWithdrawn(), 0.001);
+        assertEquals(1, s.getWithdrawalCount());
+    }
+
+    // --- OPEN transactions excluded ---
+
+    @Test
+    void openTransactionIsIgnored() {
+        // The OPEN transaction is added by the Account constructor at creation time.
+        // It should not appear in deposits or withdrawals in the summary.
+        Account acc = new Account("A", 100);
+
+        SpendingSummary s = acc.getSpendingSummary(0, Long.MAX_VALUE);
+
+        assertEquals(0.0, s.getTotalDeposited(), 0.001);
+        assertEquals(0.0, s.getTotalWithdrawn(), 0.001);
+        assertEquals(0, s.getDepositCount());
+        assertEquals(0, s.getWithdrawalCount());
+    }
+
+    // --- Date range filtering ---
+
+    @Test
+    void transactionsOutsideRangeAreExcluded() {
+        Account acc = new Account("A", 200);
+        // Before range
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 100.0, T0 - ONE_DAY);
+        // Inside range
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 50.0, T0 + ONE_DAY);
+        // After range
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 200.0, T0 + 3 * ONE_DAY);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(50.0, s.getTotalDeposited(), 0.001);
+        assertEquals(1, s.getDepositCount());
+    }
+
+    @Test
+    void transactionExactlyOnFromBoundaryIsIncluded() {
+        Account acc = new Account("A", 0);
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 10.0, T0);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + ONE_DAY);
+
+        assertEquals(10.0, s.getTotalDeposited(), 0.001);
+    }
+
+    @Test
+    void transactionExactlyOnToBoundaryIsIncluded() {
+        Account acc = new Account("A", 0);
+        long end = T0 + ONE_DAY;
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 15.0, end);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, end);
+
+        assertEquals(15.0, s.getTotalDeposited(), 0.001);
+    }
+
+    @Test
+    void emptyRangeWithNoTransactionsReturnsZeroes() {
+        Account acc = new Account("A", 100);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + ONE_DAY);
+
+        assertEquals(0.0, s.getTotalDeposited(), 0.001);
+        assertEquals(0.0, s.getTotalWithdrawn(), 0.001);
+        assertEquals(0.0, s.getNetChange(), 0.001);
+        assertEquals(0, s.getDepositCount());
+        assertEquals(0, s.getWithdrawalCount());
+    }
+
+    // --- Mixed transactions ---
+
+    @Test
+    void mixedTransactionsProduceCorrectTotals() {
+        Account acc = new Account("A", 500);
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 100.0, T0 + ONE_DAY);
+        injectTransaction(acc, bank.Transaction.Type.DEPOSIT, 200.0, T0 + ONE_DAY);
+        injectTransaction(acc, bank.Transaction.Type.WITHDRAW, 50.0, T0 + ONE_DAY);
+        injectTransaction(acc, bank.Transaction.Type.TRANSFER_IN, 75.0, T0 + ONE_DAY);
+        injectTransaction(acc, bank.Transaction.Type.TRANSFER_OUT, 25.0, T0 + ONE_DAY);
+
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + 2 * ONE_DAY);
+
+        assertEquals(375.0, s.getTotalDeposited(), 0.001);  // 100 + 200 + 75
+        assertEquals(75.0, s.getTotalWithdrawn(), 0.001);   // 50 + 25
+        assertEquals(3, s.getDepositCount());
+        assertEquals(2, s.getWithdrawalCount());
+        assertEquals(300.0, s.getNetChange(), 0.001);
+    }
+
+    // --- Summary range stored correctly ---
+
+    @Test
+    void summaryPreservesRequestedRange() {
+        Account acc = new Account("A", 0);
+        SpendingSummary s = acc.getSpendingSummary(T0, T0 + ONE_DAY);
+
+        assertEquals(T0, s.getFromMs());
+        assertEquals(T0 + ONE_DAY, s.getToMs());
+    }
+
+    // --- Via Bank API ---
+
+    @Test
+    void bankApiDelegatesCorrectlyToAccount() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("X", 300));
+        bank.getAccount("X").deposit(80);
+
+        Bank.SpendingSummaryResult r = bank.getSpendingSummary("X", 0, Long.MAX_VALUE);
+
+        assertTrue(r.isSuccess());
+        assertEquals(80.0, r.getSummary().getTotalDeposited(), 0.001);
+    }
+
+    // --- Helper: inject a transaction directly into an account's history via real operations ---
+    // We can't set timestamps directly, so we use real operations and then rely on the
+    // fixed-range tests above which use a known time window around System.currentTimeMillis().
+    // For timestamp-specific tests we use a package-accessible trick: since Transaction is
+    // constructed with an explicit timestamp, we drive it via Account.deposit/withdraw which
+    // always uses System.currentTimeMillis(). Instead we use a reflective helper only for
+    // injection tests.
+
+    private static void injectTransaction(Account acc,
+                                          bank.Transaction.Type type,
+                                          double amount,
+                                          long whenMs) {
+        // Access the transaction history list via reflection to inject at a specific timestamp.
+        // This is test-only; production code never does this.
+        try {
+            java.lang.reflect.Field f = Account.class.getDeclaredField("transactionHistory");
+            f.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.List<bank.Transaction> history = (java.util.List<bank.Transaction>) f.get(acc);
+            history.add(new bank.Transaction(type, amount, whenMs, ""));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Customers can view a breakdown of inflows vs. outflows for the active account over any date range they specify. Deposits and transfer-ins are counted as inflows; withdrawals and transfer-outs as outflows. The net change is shown alongside per-category totals and transaction counts.