### PR TITLE
Add recurring transfers feature

### DIFF
--- a/src/bank/Bank.java
+++ b/src/bank/Bank.java
@@ -1,7 +1,10 @@
 package bank;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Bank {
@@ -10,6 +13,8 @@ public class Bank {
     private static final double EPS = 1e-9;
 
     private final Map<String, Account> accounts = new LinkedHashMap<>();
+    private final List<RecurringTransfer> recurringTransfers = new ArrayList<>();
+    private int nextRecurringTransferId = 1;
 
     public void addAccount(Account account) {
         accounts.put(account.getAccountNumber(), account);
@@ -158,6 +163,86 @@ public class Bank {
         return CloseAccountResult.success();
     }
 
+    public AddRecurringTransferResult addRecurringTransfer(
+            String fromId, String toId, double amount, int intervalDays) {
+        if (fromId == null || fromId.isBlank() || toId == null || toId.isBlank()) {
+            return AddRecurringTransferResult.failure("From and to account numbers are required.");
+        }
+        if (fromId.equals(toId)) {
+            return AddRecurringTransferResult.failure("Cannot transfer to the same account.");
+        }
+        if (amount <= 0 || Double.isNaN(amount)) {
+            return AddRecurringTransferResult.failure("Transfer amount must be positive.");
+        }
+        if (intervalDays <= 0) {
+            return AddRecurringTransferResult.failure("Interval must be at least 1 day.");
+        }
+        if (accounts.get(fromId) == null) {
+            return AddRecurringTransferResult.failure("Source account not found: " + fromId);
+        }
+        if (accounts.get(toId) == null) {
+            return AddRecurringTransferResult.failure("Destination account not found: " + toId);
+        }
+
+        String id = "RT-" + nextRecurringTransferId++;
+        long nextRunMs = System.currentTimeMillis() + (long) intervalDays * 24 * 60 * 60 * 1000L;
+        recurringTransfers.add(new RecurringTransfer(id, fromId, toId, amount, intervalDays, nextRunMs, true));
+        return AddRecurringTransferResult.success(id);
+    }
+
+    public OperatorResult cancelRecurringTransfer(String id) {
+        if (id == null || id.isBlank()) {
+            return OperatorResult.failure("Recurring transfer id cannot be empty.");
+        }
+        for (RecurringTransfer rt : recurringTransfers) {
+            if (rt.getId().equals(id)) {
+                if (!rt.isActive()) {
+                    return OperatorResult.failure("Recurring transfer " + id + " is already cancelled.");
+                }
+                rt.cancel();
+                return OperatorResult.success("Recurring transfer " + id + " cancelled.");
+            }
+        }
+        return OperatorResult.failure("Recurring transfer not found: " + id);
+    }
+
+    public Collection<RecurringTransfer> getAllRecurringTransfers() {
+        return Collections.unmodifiableList(recurringTransfers);
+    }
+
+    public List<ProcessedRecurringTransferResult> processDueRecurringTransfers() {
+        long now = System.currentTimeMillis();
+        List<ProcessedRecurringTransferResult> results = new ArrayList<>();
+        for (RecurringTransfer rt : recurringTransfers) {
+            if (!rt.isActive() || rt.getNextRunMs() > now) {
+                continue;
+            }
+            TransferResult txResult = transfer(rt.getFromAccountId(), rt.getToAccountId(), rt.getAmount());
+            long intervalMs = (long) rt.getIntervalDays() * 24 * 60 * 60 * 1000L;
+            rt.setNextRunMs(rt.getNextRunMs() + intervalMs);
+            results.add(new ProcessedRecurringTransferResult(rt.getId(), txResult.isSuccess(), txResult.getMessage()));
+        }
+        return results;
+    }
+
+    public void addRecurringTransferForPersistence(RecurringTransfer rt) {
+        recurringTransfers.add(rt);
+        int num = parseRtIdNumber(rt.getId());
+        if (num >= nextRecurringTransferId) {
+            nextRecurringTransferId = num + 1;
+        }
+    }
+
+    private static int parseRtIdNumber(String id) {
+        if (id != null && id.startsWith("RT-")) {
+            try {
+                return Integer.parseInt(id.substring(3));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return 0;
+    }
+
     public static final class CreateAccountResult {
         private final boolean success;
         private final String message;
@@ -251,6 +336,62 @@ public class Bank {
 
         public static OperatorResult failure(String message) {
             return new OperatorResult(false, message);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public static final class AddRecurringTransferResult {
+        private final boolean success;
+        private final String message;
+        private final String recurringTransferId;
+
+        private AddRecurringTransferResult(boolean success, String message, String recurringTransferId) {
+            this.success = success;
+            this.message = message;
+            this.recurringTransferId = recurringTransferId;
+        }
+
+        public static AddRecurringTransferResult success(String id) {
+            return new AddRecurringTransferResult(true, "Recurring transfer " + id + " created.", id);
+        }
+
+        public static AddRecurringTransferResult failure(String message) {
+            return new AddRecurringTransferResult(false, message, null);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getRecurringTransferId() {
+            return recurringTransferId;
+        }
+    }
+
+    public static final class ProcessedRecurringTransferResult {
+        private final String recurringTransferId;
+        private final boolean success;
+        private final String message;
+
+        public ProcessedRecurringTransferResult(String recurringTransferId, boolean success, String message) {
+            this.recurringTransferId = recurringTransferId;
+            this.success = success;
+            this.message = message;
+        }
+
+        public String getRecurringTransferId() {
+            return recurringTransferId;
         }
 
         public boolean isSuccess() {

--- a/src/bank/BankPersistence.java
+++ b/src/bank/BankPersistence.java
@@ -20,6 +20,8 @@ public final class BankPersistence {
     static final String HEADER_V3 = "BANK_PERSIST_V3";
     /** V3 ACC line plus {@code |pin|fail|lock|minBalance} at end. */
     static final String HEADER_V4 = "BANK_PERSIST_V4";
+    /** V4 plus recurring transfer (RT) lines after accounts. */
+    static final String HEADER_V5 = "BANK_PERSIST_V5";
 
     private BankPersistence() {}
 
@@ -30,7 +32,7 @@ public final class BankPersistence {
     public static void save(Bank bank, String activeAccountId, Path path) throws IOException {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(HEADER_V4).append('\n');
+        sb.append(HEADER_V5).append('\n');
         sb.append("ACTIVE|").append(escapeField(activeAccountId)).append('\n');
 
         for (Account acc : bank.getAllAccounts()) {
@@ -70,6 +72,24 @@ public final class BankPersistence {
             sb.append("ENDACC\n");
         }
 
+        for (RecurringTransfer rt : bank.getAllRecurringTransfers()) {
+            sb.append("RT|")
+                    .append(escapeField(rt.getId()))
+                    .append('|')
+                    .append(escapeField(rt.getFromAccountId()))
+                    .append('|')
+                    .append(escapeField(rt.getToAccountId()))
+                    .append('|')
+                    .append(formatDouble(rt.getAmount()))
+                    .append('|')
+                    .append(rt.getIntervalDays())
+                    .append('|')
+                    .append(rt.getNextRunMs())
+                    .append('|')
+                    .append(rt.isActive() ? "1" : "0")
+                    .append('\n');
+        }
+
         Path parent = path.getParent();
         if (parent != null) {
             Files.createDirectories(parent);
@@ -99,11 +119,12 @@ public final class BankPersistence {
         }
 
         String header = lines.get(0).trim();
+        boolean formatV5 = HEADER_V5.equals(header);
         boolean formatV4 = HEADER_V4.equals(header);
         boolean formatV3 = HEADER_V3.equals(header);
         boolean formatV2 = HEADER_V2.equals(header);
         boolean formatV1 = HEADER_V1.equals(header);
-        if (!formatV4 && !formatV3 && !formatV2 && !formatV1) {
+        if (!formatV5 && !formatV4 && !formatV3 && !formatV2 && !formatV1) {
             throw new IllegalArgumentException("Missing or invalid header.");
         }
 
@@ -129,12 +150,15 @@ public final class BankPersistence {
             }
 
             if (!line.startsWith("ACC|")) {
+                if (formatV5) {
+                    break; // RT lines follow
+                }
                 throw new IllegalArgumentException("Expected ACC line, got: " + line);
             }
 
             String accPayload = line.substring("ACC|".length());
             AccLineMeta meta;
-            if (formatV4) {
+            if (formatV5 || formatV4) {
                 meta = parseAccountLineV4(accPayload);
             } else if (formatV3) {
                 meta = parseAccountLineV3(accPayload);
@@ -178,6 +202,18 @@ public final class BankPersistence {
 
         if (bank.getAccount(activeAccountId) == null) {
             activeAccountId = bank.getAllAccounts().iterator().next().getAccountNumber();
+        }
+
+        if (formatV5) {
+            while (i < lines.size()) {
+                String line = lines.get(i++).trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                if (line.startsWith("RT|")) {
+                    bank.addRecurringTransferForPersistence(parseRtLine(line.substring("RT|".length())));
+                }
+            }
         }
 
         return new BankSnapshot(bank, activeAccountId);
@@ -337,6 +373,21 @@ public final class BankPersistence {
         return new AccLineMeta(
                 accountId, balance, AccountType.SAVINGS, periodKey, withdrawals, false,
                 Account.DEFAULT_TEST_PIN, 0, false, Account.DEFAULT_MINIMUM_BALANCE_THRESHOLD);
+    }
+
+    private static RecurringTransfer parseRtLine(String payload) {
+        String[] parts = payload.split("\\|", -1);
+        if (parts.length != 7) {
+            throw new IllegalArgumentException("Malformed RT line.");
+        }
+        String id = unescapeField(parts[0]);
+        String fromId = unescapeField(parts[1]);
+        String toId = unescapeField(parts[2]);
+        double amount = Double.parseDouble(parts[3]);
+        int intervalDays = Integer.parseInt(parts[4]);
+        long nextRunMs = Long.parseLong(parts[5]);
+        boolean active = "1".equals(parts[6]);
+        return new RecurringTransfer(id, fromId, toId, amount, intervalDays, nextRunMs, active);
     }
 
     private static Transaction parseTxnLine(String line) {

--- a/src/bank/RecurringTransfer.java
+++ b/src/bank/RecurringTransfer.java
@@ -1,0 +1,59 @@
+package bank;
+
+public final class RecurringTransfer {
+
+    private final String id;
+    private final String fromAccountId;
+    private final String toAccountId;
+    private final double amount;
+    private final int intervalDays;
+    private long nextRunMs;
+    private boolean active;
+
+    public RecurringTransfer(String id, String fromAccountId, String toAccountId,
+                      double amount, int intervalDays, long nextRunMs, boolean active) {
+        this.id = id;
+        this.fromAccountId = fromAccountId;
+        this.toAccountId = toAccountId;
+        this.amount = amount;
+        this.intervalDays = intervalDays;
+        this.nextRunMs = nextRunMs;
+        this.active = active;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getFromAccountId() {
+        return fromAccountId;
+    }
+
+    public String getToAccountId() {
+        return toAccountId;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public int getIntervalDays() {
+        return intervalDays;
+    }
+
+    public long getNextRunMs() {
+        return nextRunMs;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    void setNextRunMs(long nextRunMs) {
+        this.nextRunMs = nextRunMs;
+    }
+
+    void cancel() {
+        this.active = false;
+    }
+}

--- a/src/main/MainMenu.java
+++ b/src/main/MainMenu.java
@@ -5,18 +5,20 @@ import bank.AccountType;
 import bank.Bank;
 import bank.BankPersistence;
 import bank.PinLogin;
+import bank.RecurringTransfer;
 import bank.Transaction;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 
 public class MainMenu {
 
-    private static final int EXIT_SELECTION = 12;
-    private static final int MAX_SELECTION = 12;
+    private static final int EXIT_SELECTION = 13;
+    private static final int MAX_SELECTION = 13;
 
     private final Bank bank;
     private String activeAccountId;
@@ -37,6 +39,7 @@ public class MainMenu {
         if (snapshot.isPresent()) {
             this.bank = snapshot.get().getBank();
             this.activeAccountId = snapshot.get().getActiveAccountId();
+            processDueTransfersAtStartup();
         } else {
             // No save file yet — same seed account as before persistence existed
             this.bank = new Bank();
@@ -70,7 +73,8 @@ public class MainMenu {
         System.out.println("9. View balances for all accounts");
         System.out.println("10. Operator — freeze account");
         System.out.println("11. Operator — unfreeze account");
-        System.out.println("12. Exit the app");
+        System.out.println("12. Manage recurring transfers");
+        System.out.println("13. Exit the app");
     }
 
     public int getUserSelection(int max) {
@@ -131,6 +135,10 @@ public class MainMenu {
                 break;
 
             case 12:
+                manageRecurringTransfers();
+                break;
+
+            case 13:
                 persistBankState();
                 System.out.println("Goodbye!");
                 break;
@@ -484,6 +492,120 @@ public class MainMenu {
         String line = keyboardInput.nextLine().trim();
 
         return line.equalsIgnoreCase("y") || line.equalsIgnoreCase("yes");
+    }
+
+    private void processDueTransfersAtStartup() {
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+        for (Bank.ProcessedRecurringTransferResult r : results) {
+            if (r.isSuccess()) {
+                System.out.println("[Auto-transfer] " + r.getMessage());
+            } else {
+                System.out.println("[Auto-transfer failed] " + r.getRecurringTransferId() + ": " + r.getMessage());
+            }
+        }
+    }
+
+    private void manageRecurringTransfers() {
+        System.out.println("--- Recurring Transfers ---");
+        System.out.println("1. Set up a new recurring transfer");
+        System.out.println("2. List recurring transfers");
+        System.out.println("3. Cancel a recurring transfer");
+        System.out.println("4. Process due transfers now");
+        System.out.println("5. Back");
+
+        int choice = getUserSelection(5);
+        switch (choice) {
+            case 1:
+                createRecurringTransfer();
+                break;
+            case 2:
+                listRecurringTransfers();
+                break;
+            case 3:
+                cancelRecurringTransfer();
+                break;
+            case 4:
+                processRecurringTransfersNow();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void createRecurringTransfer() {
+        if (bank.getAccountCount() < 2) {
+            System.out.println("Create another account before setting up a recurring transfer.");
+            return;
+        }
+
+        String fromId = promptNonEmptyAccountId("From account id: ");
+        if (fromId == null) return;
+
+        String toId = promptNonEmptyAccountId("To account id: ");
+        if (toId == null) return;
+
+        double amount = readPositiveMoney("Transfer amount: ");
+
+        System.out.println("Repeat every how many days? (e.g. 7 for weekly, 30 for monthly)");
+        int intervalDays = readPositiveInt("Interval (days): ");
+
+        Bank.AddRecurringTransferResult result = bank.addRecurringTransfer(fromId, toId, amount, intervalDays);
+        System.out.println(result.getMessage());
+        if (result.isSuccess()) {
+            System.out.println("First transfer will run in " + intervalDays + " day(s).");
+        }
+    }
+
+    private void listRecurringTransfers() {
+        Collection<RecurringTransfer> all = bank.getAllRecurringTransfers();
+        if (all.isEmpty()) {
+            System.out.println("No recurring transfers set up.");
+            return;
+        }
+        System.out.printf("%-8s %-10s %-10s %10s %10s %s%n",
+                "ID", "From", "To", "Amount", "Every", "Status");
+        for (RecurringTransfer rt : all) {
+            System.out.printf("%-8s %-10s %-10s %10.2f %7d day(s) %s%n",
+                    rt.getId(),
+                    rt.getFromAccountId(),
+                    rt.getToAccountId(),
+                    rt.getAmount(),
+                    rt.getIntervalDays(),
+                    rt.isActive() ? "Active" : "Cancelled");
+        }
+    }
+
+    private void cancelRecurringTransfer() {
+        listRecurringTransfers();
+        String id = promptNonEmptyAccountId("Recurring transfer id to cancel: ");
+        if (id == null) return;
+        System.out.println(bank.cancelRecurringTransfer(id).getMessage());
+    }
+
+    private void processRecurringTransfersNow() {
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+        if (results.isEmpty()) {
+            System.out.println("No transfers are due right now.");
+            return;
+        }
+        for (Bank.ProcessedRecurringTransferResult r : results) {
+            System.out.println((r.isSuccess() ? "[OK] " : "[FAILED] ") + r.getMessage());
+        }
+    }
+
+    private int readPositiveInt(String prompt) {
+        while (true) {
+            System.out.print(prompt);
+            String line = keyboardInput.nextLine().trim();
+            try {
+                int value = Integer.parseInt(line);
+                if (value > 0) {
+                    return value;
+                }
+            } catch (NumberFormatException ignored) {
+            }
+            System.out.println("Enter a positive whole number.");
+        }
     }
 
     private double readPositiveMoney(String prompt) {

--- a/src/test/BankPersistenceTest.java
+++ b/src/test/BankPersistenceTest.java
@@ -70,7 +70,7 @@ class BankPersistenceTest {
 
         BankPersistence.save(bank, "P", file);
 
-        assertEquals("BANK_PERSIST_V4", Files.readString(file).trim().split("\\R", 2)[0]);
+        assertEquals("BANK_PERSIST_V5", Files.readString(file).trim().split("\\R", 2)[0]);
 
         Account loaded = BankPersistence.load(file).getBank().getAccount("P");
         assertTrue(loaded.authenticatePin(2468));

--- a/src/test/RecurringTransferTest.java
+++ b/src/test/RecurringTransferTest.java
@@ -1,0 +1,311 @@
+package test;
+
+import bank.Account;
+import bank.AccountType;
+import bank.Bank;
+import bank.BankPersistence;
+import bank.RecurringTransfer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecurringTransferTest {
+
+    // --- Creation validation ---
+
+    @Test
+    void createRecurringTransferSucceeds() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        Bank.AddRecurringTransferResult result = bank.addRecurringTransfer("A", "B", 25.0, 30);
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.getRecurringTransferId());
+        assertTrue(result.getRecurringTransferId().startsWith("RT-"));
+    }
+
+    @Test
+    void createRecurringTransferRejectsSameAccount() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+
+        assertFalse(bank.addRecurringTransfer("A", "A", 10.0, 7).isSuccess());
+    }
+
+    @Test
+    void createRecurringTransferRejectsMissingAccount() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+
+        assertFalse(bank.addRecurringTransfer("A", "NOPE", 10.0, 7).isSuccess());
+        assertFalse(bank.addRecurringTransfer("NOPE", "A", 10.0, 7).isSuccess());
+    }
+
+    @Test
+    void createRecurringTransferRejectsNonPositiveAmount() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        assertFalse(bank.addRecurringTransfer("A", "B", 0, 7).isSuccess());
+        assertFalse(bank.addRecurringTransfer("A", "B", -5, 7).isSuccess());
+    }
+
+    @Test
+    void createRecurringTransferRejectsNonPositiveInterval() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        assertFalse(bank.addRecurringTransfer("A", "B", 10.0, 0).isSuccess());
+        assertFalse(bank.addRecurringTransfer("A", "B", 10.0, -1).isSuccess());
+    }
+
+    // --- Listing ---
+
+    @Test
+    void newlyCreatedTransferAppearsInList() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        bank.addRecurringTransfer("A", "B", 50.0, 7);
+
+        Collection<RecurringTransfer> all = bank.getAllRecurringTransfers();
+        assertEquals(1, all.size());
+        RecurringTransfer rt = all.iterator().next();
+        assertEquals("A", rt.getFromAccountId());
+        assertEquals("B", rt.getToAccountId());
+        assertEquals(50.0, rt.getAmount(), 0.001);
+        assertEquals(7, rt.getIntervalDays());
+        assertTrue(rt.isActive());
+    }
+
+    @Test
+    void idsAreUnique() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 200));
+        bank.addAccount(new Account("B", 0));
+
+        String id1 = bank.addRecurringTransfer("A", "B", 10.0, 7).getRecurringTransferId();
+        String id2 = bank.addRecurringTransfer("A", "B", 20.0, 14).getRecurringTransferId();
+
+        assertFalse(id1.equals(id2));
+    }
+
+    // --- Cancellation ---
+
+    @Test
+    void cancelRecurringTransferSucceeds() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        String id = bank.addRecurringTransfer("A", "B", 10.0, 7).getRecurringTransferId();
+        Bank.OperatorResult cancel = bank.cancelRecurringTransfer(id);
+
+        assertTrue(cancel.isSuccess());
+        RecurringTransfer rt = bank.getAllRecurringTransfers().iterator().next();
+        assertFalse(rt.isActive());
+    }
+
+    @Test
+    void cancelNonExistentIdFails() {
+        Bank bank = new Bank();
+        assertFalse(bank.cancelRecurringTransfer("RT-99").isSuccess());
+    }
+
+    @Test
+    void cancelAlreadyCancelledFails() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        String id = bank.addRecurringTransfer("A", "B", 10.0, 7).getRecurringTransferId();
+        bank.cancelRecurringTransfer(id);
+
+        assertFalse(bank.cancelRecurringTransfer(id).isSuccess());
+    }
+
+    // --- Processing due transfers ---
+
+    @Test
+    void dueTransferExecutesAndAdvancesSchedule() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        // Manually add an RT whose nextRunMs is in the past
+        bank.addRecurringTransferForPersistence(
+                new RecurringTransfer("RT-1", "A", "B", 30.0, 7,
+                        System.currentTimeMillis() - 1000, true));
+
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).isSuccess());
+        assertEquals(70.0, bank.getAccount("A").getBalance(), 0.001);
+        assertEquals(30.0, bank.getAccount("B").getBalance(), 0.001);
+
+        // Schedule should have advanced by one interval
+        RecurringTransfer rt = bank.getAllRecurringTransfers().iterator().next();
+        assertTrue(rt.getNextRunMs() > System.currentTimeMillis());
+    }
+
+    @Test
+    void notYetDueTransferIsSkipped() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        bank.addRecurringTransferForPersistence(
+                new RecurringTransfer("RT-1", "A", "B", 30.0, 30,
+                        System.currentTimeMillis() + 999_999_000L, true));
+
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+
+        assertTrue(results.isEmpty());
+        assertEquals(100.0, bank.getAccount("A").getBalance(), 0.001);
+    }
+
+    @Test
+    void cancelledTransferIsNotProcessed() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+
+        bank.addRecurringTransferForPersistence(
+                new RecurringTransfer("RT-1", "A", "B", 30.0, 7,
+                        System.currentTimeMillis() - 1000, false));
+
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+
+        assertTrue(results.isEmpty());
+        assertEquals(100.0, bank.getAccount("A").getBalance(), 0.001);
+    }
+
+    @Test
+    void insufficientFundsTransferReportsFailureButAdvancesSchedule() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 5));
+        bank.addAccount(new Account("B", 0));
+
+        bank.addRecurringTransferForPersistence(
+                new RecurringTransfer("RT-1", "A", "B", 50.0, 7,
+                        System.currentTimeMillis() - 1000, true));
+
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).isSuccess());
+        // Balance unchanged
+        assertEquals(5.0, bank.getAccount("A").getBalance(), 0.001);
+        // Schedule still advanced
+        RecurringTransfer rt = bank.getAllRecurringTransfers().iterator().next();
+        assertTrue(rt.getNextRunMs() > System.currentTimeMillis());
+    }
+
+    @Test
+    void frozenSourceAccountTransferReportsFailure() {
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 100));
+        bank.addAccount(new Account("B", 0));
+        bank.setAccountFrozen("A", true);
+
+        bank.addRecurringTransferForPersistence(
+                new RecurringTransfer("RT-1", "A", "B", 20.0, 7,
+                        System.currentTimeMillis() - 1000, true));
+
+        List<Bank.ProcessedRecurringTransferResult> results = bank.processDueRecurringTransfers();
+
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).isSuccess());
+    }
+
+    // --- Persistence ---
+
+    @Test
+    void recurringTransfersSurviveRoundTrip(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("bank.txt");
+
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 500));
+        bank.addAccount(new Account("B", 0));
+        bank.addRecurringTransfer("A", "B", 100.0, 14);
+        String id = bank.getAllRecurringTransfers().iterator().next().getId();
+
+        BankPersistence.save(bank, "A", file);
+        Bank loaded = BankPersistence.load(file).getBank();
+
+        Collection<RecurringTransfer> rts = loaded.getAllRecurringTransfers();
+        assertEquals(1, rts.size());
+        RecurringTransfer rt = rts.iterator().next();
+        assertEquals(id, rt.getId());
+        assertEquals("A", rt.getFromAccountId());
+        assertEquals("B", rt.getToAccountId());
+        assertEquals(100.0, rt.getAmount(), 0.001);
+        assertEquals(14, rt.getIntervalDays());
+        assertTrue(rt.isActive());
+    }
+
+    @Test
+    void cancelledRecurringTransferPersistedAsCancelled(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("bank.txt");
+
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 500));
+        bank.addAccount(new Account("B", 0));
+        String id = bank.addRecurringTransfer("A", "B", 50.0, 7).getRecurringTransferId();
+        bank.cancelRecurringTransfer(id);
+
+        BankPersistence.save(bank, "A", file);
+        Bank loaded = BankPersistence.load(file).getBank();
+
+        RecurringTransfer rt = loaded.getAllRecurringTransfers().iterator().next();
+        assertFalse(rt.isActive());
+    }
+
+    @Test
+    void idsDoNotClashAfterLoadAndCreate(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("bank.txt");
+
+        Bank bank = new Bank();
+        bank.addAccount(new Account("A", 500));
+        bank.addAccount(new Account("B", 0));
+        bank.addRecurringTransfer("A", "B", 10.0, 7);
+
+        BankPersistence.save(bank, "A", file);
+        Bank loaded = BankPersistence.load(file).getBank();
+
+        // Add a second RT after loading — its ID must not clash with the persisted one
+        String existingId = loaded.getAllRecurringTransfers().iterator().next().getId();
+        String newId = loaded.addRecurringTransfer("A", "B", 20.0, 14).getRecurringTransferId();
+        assertFalse(existingId.equals(newId));
+    }
+
+    @Test
+    void v4FileLoadsWithEmptyRecurringTransfers(@TempDir Path tempDir) throws Exception {
+        // Write a hand-crafted V4 file and confirm it loads without error
+        Path file = tempDir.resolve("v4.txt");
+        String v4Content = "BANK_PERSIST_V4\n"
+                + "ACTIVE|A001\n"
+                + "ACC|A001|100.0|CHECKING|0|1234|0|0|25.0\n"
+                + "TXN|OPEN|100.0|1000000000000|Checking — Opened with balance 100.0\n"
+                + "ENDACC\n";
+        java.nio.file.Files.writeString(file, v4Content);
+
+        Bank loaded = BankPersistence.load(file).getBank();
+        assertTrue(loaded.getAllRecurringTransfers().isEmpty());
+    }
+}


### PR DESCRIPTION
Customers can schedule automatic transfers between two accounts on a repeating interval (any number of days). Due transfers run automatically when the app loads and can also be triggered manually from the menu. Recurring transfers survive app restarts via a new BANK_PERSIST_V5 format (fully backward-compatible with V1–V4 save files).